### PR TITLE
Fix

### DIFF
--- a/update-is
+++ b/update-is
@@ -25,9 +25,31 @@ then
       touch CNAME
     fi
     echo "beta.sequencer.publiclab.org" > CNAME
+    
+    rm -R docs/
+    rm -R spec/
+    rm -R test/
+    rm CONTRIBUTING.md
+    rm index.js
+    
+    cp src/ui/prepareDynamic.js prepareDynamic.js
+    
+    rm -R src/
+    mkdir -p src/ui/
+    mv prepareDynamic.js src/ui/prepareDynamic.js
 
     git add .
-    git add -f node_modules/
+    git add -f node_modules/jquery/
+    git add -f node_modules/bootstrap/
+    git add -f node_modules/imgareaselect/
+    git add -f node_modules/gifshot/
+    git add -f node_modules/downloadjs/
+    git add -f node_modules/selectize/
+    git add -f node_modules/font-awesome/
+    
+    git add -f dist/image-sequencer.js
+    git add -f dist/image-sequencer-ui.js
+    
     git commit -m "update"
     git push
 


### PR DESCRIPTION
Fixes https://github.com/publiclab/image-sequencer/issues/948

It actually wasn't working because the dist is gitignored so it has to force pushed. Now that has been fixed. Also, only the required node modules are pushed and other directories like src and test are removed.